### PR TITLE
Fix `libf77blas.so.3: cannot open shared object file: No such file or directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ apt-get update
 apt-get install python-pip python-dev
 
 # For Python 3.5
-apt-get install python3-pip python3-dev
+apt-get install python3-pip python3-dev libatlas-base-dev
 ```
 
 Next, download the wheel file from this repository and install it:
@@ -59,4 +59,3 @@ b'Hello, TensorFlow!'
 ```
 
 **Note: These are unofficial binaries (though built from the minimally modified official source), and thus there is no expectation of support from the TensorFlow team. Please don't create issues for these files in the official TensorFlow repository.**
-


### PR DESCRIPTION
Hi Asa! I got [this error](https://github.com/Kitt-AI/snowboy/issues/262) when I try to run `import tensorflow as tf` with Python3. We might have to install `libatlas-base-dev` in advance.